### PR TITLE
Add duplex option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: "14"
+          node-version: "20"
 
       - name: Install dependencies
         run: |

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "private": true,
   "scripts": {
     "clean": "rimraf output && rimraf .pulp-cache",
-    "build": "eslint src && pulp build -- --censor-lib --strict"
+    "build": "eslint src && pulp build -- --censor-lib --strict",
+    "test": "spago -x test.dhall test"
   },
   "devDependencies": {
     "eslint": "^7.15.0",

--- a/src/Fetch/Core/Duplex.purs
+++ b/src/Fetch/Core/Duplex.purs
@@ -1,0 +1,21 @@
+module Fetch.Core.Duplex where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+
+data Duplex = Half | Full
+
+derive instance Eq Duplex
+derive instance Ord Duplex
+
+toString :: Duplex -> String
+toString = case _ of
+  Half -> "half"
+  Full -> "full"
+
+fromString :: String -> Maybe Duplex
+fromString = case _ of
+  "full" -> Just Full
+  "half" -> Just Half
+  _ -> Nothing

--- a/src/Fetch/Core/Request.purs
+++ b/src/Fetch/Core/Request.purs
@@ -20,6 +20,8 @@ import Data.Newtype (un)
 import Data.Symbol (class IsSymbol)
 import Effect (Effect)
 import Effect.Uncurried (EffectFn2, runEffectFn2)
+import Fetch.Core.Duplex (Duplex)
+import Fetch.Core.Duplex as Duplex
 import Fetch.Core.Headers (Headers)
 import Fetch.Core.Integrity (Integrity(..))
 import Fetch.Core.Referrer (Referrer)
@@ -53,6 +55,7 @@ type UnsafeRequestOptions =
   , referrer :: String
   , referrerPolicy :: String
   , integrity :: String
+  , duplex :: String
   )
 
 type RequestOptions =
@@ -65,6 +68,7 @@ type RequestOptions =
   , referrer :: Referrer
   , referrerPolicy :: ReferrerPolicy
   , integrity :: Integrity
+  , duplex :: Duplex
   )
 
 toUnsafeOptions
@@ -150,3 +154,5 @@ instance ToInternalConverter ReferrerPolicy String where
 instance ToInternalConverter Integrity String where
   convertImpl = un Integrity
 
+instance ToInternalConverter Duplex String where
+  convertImpl = Duplex.toString

--- a/test.dhall
+++ b/test.dhall
@@ -6,10 +6,9 @@ in      conf
               conf.dependencies
             # [ "aff"
               , "aff-promise"
-              , "effect"
-              , "spec"
-              , "spec-discovery"
-              , "strings"
+              , "console"
               , "debug"
+              , "effect"
+              , "unsafe-coerce"
               ]
         }

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -23,7 +23,6 @@ main = launchAff_ do
     { method: POST
     , body: RequestBody.fromString requestBody
     , headers: Headers.fromRecord { "Content-Type": "application/json" }
-    , duplex
     }
   let
     _ = spy "request" request

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -6,10 +6,11 @@ import Control.Promise as Promise
 import Data.HTTP.Method (Method(..))
 import Debug (spy)
 import Effect (Effect)
-import Effect.Aff (launchAff, launchAff_)
+import Effect.Aff (launchAff_)
 import Effect.Class (liftEffect)
 import Effect.Class.Console (log)
 import Fetch.Core as Fetch
+import Fetch.Core.Duplex (Duplex(..))
 import Fetch.Core.Headers as Headers
 import Fetch.Core.Request as Request
 import Fetch.Core.RequestBody as RequestBody
@@ -23,9 +24,9 @@ main = launchAff_ do
     { method: POST
     , body: RequestBody.fromString requestBody
     , headers: Headers.fromRecord { "Content-Type": "application/json" }
+    , duplex: Half
     }
-  let
-    _ = spy "request" request
+  let _ = spy "request" request
   response <- Promise.toAffE $ unsafeCoerce $ Fetch.fetch request
   responseBody <- Promise.toAffE $ unsafeCoerce $ Response.text response
   let _ = spy "response" response

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -20,10 +20,11 @@ main :: Effect Unit
 main = launchAff_ do
   let requestBody = """{"hello":"world"}"""
   request <- liftEffect $ Request.new "http://httpbin.org/post"
-      { method: POST
-      , body: RequestBody.fromString requestBody
-      , headers: Headers.fromRecord { "Content-Type": "application/json" }
-      }
+    { method: POST
+    , body: RequestBody.fromString requestBody
+    , headers: Headers.fromRecord { "Content-Type": "application/json" }
+    , duplex
+    }
   let
     _ = spy "request" request
   response <- Promise.toAffE $ unsafeCoerce $ Fetch.fetch request


### PR DESCRIPTION
**Description of the change**

Fetch requests with a body need to set the 'duplex' option. Specifically, right now, it should be set to 'half', although in the (near) future that may change as browsers add support for a 'full' option as well. Currently it is technically possible to set to one or the other so I have chosen to support an option for both.

See:
- https://github.com/nodejs/node/issues/46221
- https://developer.chrome.com/articles/fetch-streaming-requests/#half-duplex